### PR TITLE
`README.md` and `Dockerfile` tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN echo 'options("repos"="http://cloud.r-project.org")' >> /usr/local/lib/R/etc
 
 ## More verbose UBSAN/SAN output (cf #3) -- this is still somewhat speculative
 ## Entry copied from Prof Ripley's setup described at http://www.stats.ox.ac.uk/pub/bdr/memtests/README.txt
-ENV ASAN_OPTIONS 'alloc_dealloc_mismatch=0:detect_leaks=0:detect_odr_violation=0' 
+ENV ASAN_OPTIONS='alloc_dealloc_mismatch=0:detect_leaks=0:detect_odr_violation=0'
 
 RUN cd /usr/local/bin \
 	&& mv R Rdevel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 FROM r-base:latest
 
 ## This handle reaches Carl and Dirk
-MAINTAINER "Carl Boettiger and Dirk Eddelbuettel" rocker-maintainers@eddelbuettel.com
+LABEL org.opencontainers.image.authors="Carl Boettiger and Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com>"
+
 
 ## Remain current
 RUN apt-get update -qq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,4 +114,4 @@ RUN cd /usr/local/bin \
 	&& ln -s Rdevel RD \
 	&& ln -s Rscriptdevel RDscript
 
-
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ and to
 [Using the Undefined Behaviour Sanitizer](http://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Using-Undefined-Behaviour-Sanitizer).
 
 Both require a particularly instrumented binary of R.  This repository
-provides a Docker container with such a binary, based on the R-devel sources.
+provides a Docker container with such a binary, based on the R-devel sources:
+
+* This particularly instrumented binary of `R` is available on the path as `Rdevel` and for convenience is also symbolically linked on the path as `RD`.
+* The particularly instrumented versions of `Rscript` on the path are `Rscriptdevel` with symbolic link `RDscript` for convenience.
+* The `R` and `Rscript` binaries in the path of this container are inherited from the `r-base/latest` container and are **not** particularly instrumented with sanitizer support.
 
 ## Rocker-Org
 


### PR DESCRIPTION
Four proposed tweaks:

* Explicitly mention in `README.md` which binaries are particularly instrumented with sanitizer support
* Update default `CMD` to use the particularly instrumented version of R with sanitizer support
* Remove two deprecation warnings when building the `Dockerfile`:

  + Use `ENV key=value` instead of deprecated `ENV key value`
  + Use `LABEL org.opencontainers.image.authors` instead of deprecated `MAINTAINER`

If only some of these changes are wanted let me know and I can drop any unwanted ones with a `git rebase -i master` and then `git push --force` an update with only the wanted changes.  Thanks!